### PR TITLE
support cmake with linux building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.0.2)
+
+project(TieGunner)
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+  set(CMAKE_C_FLAGS "-std=c11 ${CMAKE_C_FLAGS}")
+endif()
+
+file(GLOB_RECURSE source_files src/*.c)
+
+if(APPLE)
+  list(REMOVE_ITEM source_files ${CMAKE_CURRENT_SOURCE_DIR}/src/os_win.c ${CMAKE_CURRENT_SOURCE_DIR}/src/os_unix.c)
+
+elseif(WIN32)
+  list(REMOVE_ITEM source_files ${CMAKE_CURRENT_SOURCE_DIR}/src/os_mac.c ${CMAKE_CURRENT_SOURCE_DIR}/src/os_unix.c)
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+  link_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib)
+elseif(UNIX)
+  list(REMOVE_ITEM source_files ${CMAKE_CURRENT_SOURCE_DIR}/src/os_mac.c ${CMAKE_CURRENT_SOURCE_DIR}/src/os_win.c)
+  set(ENVIRONMENT_SPECIFIC_LIBRARIES "m")
+else()
+  message(FATAL "this system is not supported yet.")
+endif()
+
+add_executable(TieGunner ${source_files})
+
+find_package(OpenGL REQUIRED)
+find_package(GLUT REQUIRED)
+find_package(OpenAL REQUIRED)
+find_package(PNG REQUIRED)
+find_package(ZLIB REQUIRED)
+
+include_directories(
+  ${OPENGL_INCLUDE_DIRS}
+  ${GLUT_INCLUDE_DIRS}
+  ${OPENAL_INCLUDE_DIR}
+  ${PNG_INCLUDE_DIR}
+  ${ZLIB_INCLUDE_DIRS}
+)
+
+target_link_libraries(TieGunner
+  ${OPENGL_LIBRARIES}
+  ${GLUT_LIBRARY}
+  ${OPENAL_LIBRARY}
+  ${PNG_LIBRARY}
+  ${ZLIB_LIBRARIES}
+  ${ENVIRONMENT_SPECIFIC_LIBRARIES}
+)


### PR DESCRIPTION
testing:

``` zsh
cmake -G Ninja -DCMAKE_BUILD_TYPE=release ..
-- The C compiler identification is GNU 4.9.2
-- The CXX compiler identification is GNU 4.9.2
-- Check for working C compiler using: Ninja
-- Check for working C compiler using: Ninja -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler using: Ninja
-- Check for working CXX compiler using: Ninja -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Looking for XOpenDisplay in /usr/lib/x86_64-linux-gnu/libX11.so;/usr/lib/x86_64-linux-gnu/libXext.so
-- Looking for XOpenDisplay in /usr/lib/x86_64-linux-gnu/libX11.so;/usr/lib/x86_64-linux-gnu/libXext.so - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for connect
-- Looking for connect - found
-- Looking for remove
-- Looking for remove - found
-- Looking for shmat
-- Looking for shmat - found
-- Looking for IceConnectionNumber in ICE
-- Looking for IceConnectionNumber in ICE - found
-- Found X11: /usr/lib/x86_64-linux-gnu/libX11.so
-- Found OpenGL: /usr/lib/x86_64-linux-gnu/libGL.so  
-- Found GLUT: /usr/lib/x86_64-linux-gnu/libglut.so  
-- Found OpenAL: /usr/lib/x86_64-linux-gnu/libopenal.so  
-- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.8") 
-- Found PNG: /usr/lib/x86_64-linux-gnu/libpng.so (found version "1.2.51") 
-- Configuring done
-- Generating done
-- Build files have been written to: /home/usagi/repos/TieGunner.usagi/build
```

```
time ninja
[13/50] Building C object CMakeFiles/TieGunner.dir/src/co_file.c.o
../src/co_file.c: In function ‘FsMountImage’:
../src/co_file.c:213:4: warning: implicit declaration of function ‘ntohl’ [-Wimplicit-function-declaration]
    h_size = ntohl(tmp_b);
    ^
[38/50] Building C object CMakeFiles/TieGunner.dir/src/co_zlib.c.o
../src/co_zlib.c: In function ‘ZlibEncode’:
../src/co_zlib.c:81:2: warning: implicit declaration of function ‘htonl’ [-Wimplicit-function-declaration]
  *(u_int *)dst = htonl(size);     // ���f�[�^�T�C�Y���L�^
  ^
../src/co_zlib.c: In function ‘ZlibEncodeSize’:
../src/co_zlib.c:265:2: warning: implicit declaration of function ‘ntohl’ [-Wimplicit-function-declaration]
  return ntohl(*((u_int *)ptr + 1));
  ^
[48/50] Building C object CMakeFiles/TieGunner.dir/src/nn_main.c.o
../src/nn_main.c: In function ‘readReplayInfo’:
../src/nn_main.c:181:2: warning: implicit declaration of function ‘ntohl’ [-Wimplicit-function-declaration]
  *(int *)(&info->player_pos.x) = ntohl(value);
  ^
../src/nn_main.c: In function ‘writeReplayInfo’:
../src/nn_main.c:211:2: warning: implicit declaration of function ‘htonl’ [-Wimplicit-function-declaration]
  value = htonl(*(u_int *)(&info->player_pos.x));
  ^
[49/50] Building C object CMakeFiles/TieGunner.dir/src/co_input.c.o
../src/co_input.c: In function ‘putIntValue’:
../src/co_input.c:719:2: warning: implicit declaration of function ‘htonl’ [-Wimplicit-function-declaration]
  *(u_int *)(ptr + ofs) = htonl(value);
  ^
../src/co_input.c: In function ‘getIntValue’:
../src/co_input.c:737:2: warning: implicit declaration of function ‘ntohl’ [-Wimplicit-function-declaration]
  return ntohl(*ptr);
  ^
[50/50] Linking C executable TieGunner
ninja  4.78s user 0.50s system 354% cpu 1.489 total
```

testing-environment:
- OS: Ubuntu-15.04 / Kernel 3.19.0 (x86_64)
- GCC: 4.9.2
- CMake: 3.0.2
